### PR TITLE
Timeline changes (and other minor GUI changes)

### DIFF
--- a/winlogtimeline/ui/ui.py
+++ b/winlogtimeline/ui/ui.py
@@ -9,8 +9,6 @@ from winlogtimeline import collector
 
 import os
 
-current_project = None
-
 
 class GUI(Tk):
     def __init__(self, *args, **kwargs):
@@ -20,6 +18,7 @@ class GUI(Tk):
         self.minsize(width=800, height=600)
 
         self.program_config = util.data.open_config()
+        self.current_project = None
 
         self.menu_bar = MenuBar(self, tearoff=False)
         self.status_bar = StatusBar(self)
@@ -30,16 +29,71 @@ class GUI(Tk):
         self.__disable__()
         self.protocol('WM_DELETE_WINDOW', self.__destroy__)
 
-    def refresh_timeline(self):
-        records = current_project.get_all_logs()
-        if len(records) > 0:
-            headers = records[0].get_headers()
-            self.event_section = self.create_new_timeline(headers, [record.get_tuple() for record in records])
+    def open_project(self, project_path):
+        """
+        Opens a project. This will create it if it doesn't already exist.
+        :param project_path: The path to the project elv file.
+        :return:
+        """
+        self.current_project = util.project.Project(project_path)
+        self.create_new_timeline()
+        self.__enable__()
 
-    def create_new_timeline(self, headers, data):
+    def close_project(self):
+        """
+        Prompts the user to save the project and then closes it.
+        :return:
+        """
+        if self.current_project is not None:
+            answer = messagebox.askquestion(title='Save Before Close',
+                                            message='Would you like to save the currently opened project before '
+                                                    'closing it?', type=messagebox.YESNOCANCEL)
+
+            if answer == messagebox.YES:
+                self.current_project.close()
+                self.current_project = None
+            elif answer == messagebox.NO:
+                self.current_project = None
+            else:
+                return
+
         if self.event_section is not None:
             self.event_section.pack_forget()
-        return EventSection(self, headers, data)
+            self.event_section = None
+
+    def create_new_timeline(self, headers=None, records=None):
+        """
+        Function for creating/updating the event section.
+        :param headers: A tuple containing the column titles. These should be in the same order as the values in
+        records.
+        :param records: A list of tuples containing the record values.
+        :return:
+        """
+        def callback(h=headers, r=records):
+            # Disable all timeline interaction buttons to prevent a timeline duplication bug
+            self.__disable__()
+
+            # Get all records if they weren't provided
+            if r is None:
+                r = self.current_project.get_all_logs()
+                if len(r) == 0:
+                    self.__enable__()
+                    return
+                h = r[0].get_headers()
+                r = [record.get_tuple() for record in r]
+
+            # Delete the old timeline if it exists
+            if self.event_section is not None:
+                self.event_section.pack_forget()
+
+            # Create the new timeline
+            self.event_section = EventSection(self, h, r)
+
+            # Enable all timeline interaction buttons
+            self.__enable__()
+
+        t = Thread(target=callback)
+        t.start()
 
     def __disable__(self):
         self.toolbar.__disable__()
@@ -50,21 +104,7 @@ class GUI(Tk):
         self.query_bar.__enable__()
 
     def __destroy__(self):
-        global current_project
-
-        if current_project is not None:
-            answer = messagebox.askquestion(title='Save Before Close',
-                                            message='Would you like to save the currently opened project before '
-                                                    'closing it?', type=messagebox.YESNOCANCEL)
-
-            if answer == messagebox.YES:
-                current_project.close()
-                current_project = None
-            elif answer == messagebox.NO:
-                current_project = None
-            else:
-                return
-
+        self.close_project()
         self.destroy()
 
 
@@ -98,6 +138,7 @@ class EventSection(Frame):
             self.tree.insert('', 'end', values=val, tags=str(val[1]))
 
             # Adjust column widths if necessary
+            # TODO: See if this can be sped up
             for i, v in enumerate(val):
                 width = font.Font().measure(v)
                 if self.tree.column(self.headers[i], width=None) < width:
@@ -183,8 +224,7 @@ class Toolbar(Frame):
         self.format_button.config(state=NORMAL)
 
     def import_function(self):
-        global current_project
-        file_path = filedialog.askopenfilename(title='Open a Project File',
+        file_path = filedialog.askopenfilename(title='Open an event log file',
                                                filetypes=(('Windows Event Log File', '*.evtx'),))
 
         if len(file_path) == 0:
@@ -192,16 +232,16 @@ class Toolbar(Frame):
 
         file_path = os.path.abspath(file_path)
 
-        def callback(self=self):
+        def callback():
             text = '{file}: {status}'.format(file=os.path.basename(file_path), status='{status}')
 
             def update_progress(status):
                 self.master.status_bar.status.config(text=text.format(status=status))
 
             update_progress('Waiting to start')
-            collector.import_log(file_path, current_project, '', update_progress)
+            collector.import_log(file_path, self.master.current_project, '', update_progress)
 
-            self.master.refresh_timeline()
+            self.master.create_new_timeline()
 
         t = Thread(target=callback)
         t.start()
@@ -237,66 +277,38 @@ class MenuBar(Menu):
         self.file_menu.add_command(label='Save', command=self.save_project_function, underline=0,
                                    accelerator='Ctrl+S')
         parent.bind_all('<Control-s>', self.open_project_function)
-        # self.fileMenu.add_command(label='Save Project', command=lambda: self.saveProjectFunction())
 
     def new_project_function(self, event=None):
-        global current_project
-
-        if current_project is not None:
-            answer = messagebox.askquestion(title='Save Before Close',
-                                            message='Would you like to save the currently opened project before '
-                                                    'closing it?', type=messagebox.YESNOCANCEL)
-
-            if answer == messagebox.YES:
-                current_project.close()
-                current_project = None
-            elif answer == messagebox.NO:
-                current_project = None
-            else:
-                return
-
+        """
+        Callback function for File -> New. Closes the current project and kicks of the project creation wizard.
+        :param event: A click or key press event.
+        :return:
+        """
+        self.master.close_project()
+        # TODO: Project creation wizard
         project_path = os.path.join(util.data.get_appdir(), 'Projects', 'New Project', 'New Project.elv')
-        current_project = util.project.Project(project_path)
-        self.master.status_bar.status.config(text='Project created at ' + current_project.get_path())
-        self.master.__enable__()
-
-        # Set up the timeline
-        self.master.refresh_timeline()
-
-        return
+        self.master.open_project(project_path)
+        self.master.status_bar.status.config(text='Project created at ' + self.master.current_project.get_path())
 
     def open_project_function(self, event=None):
-        global current_project
-
-        if current_project is not None:
-            answer = messagebox.askquestion(title='Save Before Close',
-                                            message='Would you like to save the currently opened project before '
-                                                    'closing it?', type=messagebox.YESNOCANCEL)
-
-            if answer == messagebox.YES:
-                current_project.close()
-                current_project = None
-            elif answer == messagebox.NO:
-                current_project = None
-            else:
-                return
-
+        """
+        Callback function for File -> Open. Closes the current project and kicks off the open project UI.
+        :param event: A click or key press event.
+        :return:
+        """
+        self.master.close_project()
         projects_path = os.path.join(util.data.get_appdir(), 'Projects')
         filename = filedialog.askopenfilename(initialdir=projects_path, title='Open a Project File',
                                               filetypes=(('ELV Project File', '*.elv'),))
-        if len(filename) == 0:
-            return
-
-        current_project = util.project.Project(filename)
-        self.master.status_bar.status.config(text='Project opened at ' + current_project.get_path())
-        self.master.__enable__()
-
-        self.master.refresh_timeline()
-
-        return
+        if len(filename) > 0:
+            self.master.open_project(projects_path)
+            self.master.status_bar.status.config(text='Project opened at ' + self.master.current_project.get_path())
 
     def save_project_function(self, event=None):
-        global current_project
-        current_project.save()
+        """
+        Callback function for File -> Save. Saves the current project.
+        :param event: A click or key press event.
+        :return:
+        """
+        self.master.current_project.save()
         self.master.status_bar.status.config(text='Project saved!')
-        return

--- a/winlogtimeline/ui/ui.py
+++ b/winlogtimeline/ui/ui.py
@@ -131,7 +131,6 @@ class EventSection(Frame):
 
         # Set up the columns
         for col in self.headers:
-            print(col)
             self.tree.heading(col, text=col.title(), command=lambda _col=col: self.sort_column(_col, False))
             self.tree.column(col, width=col_width[col])
 


### PR DESCRIPTION
**Highlights**

* Fixed the duplicate timeline issue.

  * Cause: Creating a timeline while the previous one was still in the process of being created caused a failure in the check to unpack the previous timeline. This is because the initial timeline creation process had yet to return, and the `event_section` variable was still null.

  * Fix: Disable timeline interaction (log import, filtering, and querying) while the timeline is being created. 

* Streamed the timeline creation process by calculating column widths before inserting rows, rather than as they were being inserted. This means that the columns are only being resized a single time, which prevents the blank space on the right-hand side of the event section that I was seeing before. I also moved the placement call (in this case, grid) to the end of the event section initialization for the same reason. 

* Moved the `current_project` global variable to a variable in the GUI root as was previously discussed. 

* Refactored the open/close project functions to remove redundant code and improve readability. 

* Moved timeline creation to a separate thread to prevent the GUI from freezing.

* Added documentation for various methods that I was working on. 

* Added status updates during the timeline creation process. 

**Issues**

* The UI is still resized when the timeline is created, and I'd like to find a way to prevent that. Unfortunately, I haven't found a fix yet. 