### PR TITLE
Progress bar, UI fixes and tweaks

### DIFF
--- a/winlogtimeline/ui/import_window.py
+++ b/winlogtimeline/ui/import_window.py
@@ -6,7 +6,7 @@ from winlogtimeline import util
 import os
 
 
-class ImportWizard(Toplevel):
+class ImportWindow(Toplevel):
     def __init__(self, parent):
         super().__init__(parent)
 

--- a/winlogtimeline/ui/import_window.py
+++ b/winlogtimeline/ui/import_window.py
@@ -13,9 +13,8 @@ class ImportWizard(Toplevel):
         # Class variables
 
         # Window parameters
-        self.title('Import Files')
+        self.title('Import Log Files')
         self.resizable(width=False, height=False)
-        self.minsize(width=400, height=100)
 
         # Create and place the widgets
         self._init_widgets()
@@ -31,9 +30,10 @@ class ImportWizard(Toplevel):
 
         # Workspace block
         self.sv_file = StringVar()
-        self.label_file = Label(self.container, text='File:')
-        self.entry_file = Entry(self.container, textvariable=self.sv_file)
-        self.button_file = Button(self.container, text='...', width=1, command=self.callback_path_prompt)
+        self.path_container = Frame(self.container)
+        self.label_file = Label(self.path_container, text='File:')
+        self.entry_file = Entry(self.path_container, width=60, textvariable=self.sv_file)
+        self.button_file = Button(self.path_container, width=3, text='...', command=self.callback_path_prompt)
 
         # Alias block
         self.sv_alias = StringVar()
@@ -60,18 +60,20 @@ class ImportWizard(Toplevel):
         # Workspace block
         self.label_file.grid(row=0, column=0, padx=padding, sticky='SW')
         self.entry_file.grid(row=1, column=0, columnspan=4, padx=padding, pady=padding, sticky='NESW')
-        self.button_file.grid(row=1, column=5, padx=padding, pady=padding, sticky='EW')
+        self.button_file.grid(row=1, column=4, padx=padding, pady=padding, sticky='EW')
+        self.path_container.columnconfigure(0, weight=4)
+        self.path_container.grid(row=0, column=0, columnspan=5, rowspan=2, sticky='EW')
 
-        # Title block
+        # Alias block
         self.label_alias.grid(row=2, column=0, padx=padding, sticky='SW')
-        self.entry_alias.grid(row=3, column=0, padx=padding, pady=padding, sticky='NESW')
+        self.entry_alias.grid(row=3, column=0, columnspan=5, padx=padding, pady=padding, sticky='NESW')
 
         # Action block
-        self.button_cancel.grid(row=6, column=2, padx=padding, pady=padding, sticky='EW')
-        self.button_import.grid(row=6, column=3, padx=padding, pady=padding, sticky='EW')
+        self.button_cancel.grid(row=6, column=3, padx=padding, pady=padding, sticky='EW')
+        self.button_import.grid(row=6, column=4, padx=padding, pady=padding, sticky='EW')
 
-        # Specify which portion to auto-expand
-        self.columnconfigure(0, weight=4)
+        # Specify which column to auto expand
+        self.container.columnconfigure(0, weight=4)
 
         # Place the container frame
         self.container.pack(fill=BOTH)

--- a/winlogtimeline/ui/new_project.py
+++ b/winlogtimeline/ui/new_project.py
@@ -31,17 +31,21 @@ class NewProject(Toplevel):
         # Workspace block
         self.sv_workspace = StringVar()
         self.sv_workspace.trace('w', lambda *args: self.callback_update_path())
-        self.label_workspace = Label(self.container, text='Workspace:')
-        self.entry_workspace = Entry(self.container, textvariable=self.sv_workspace)
-        self.button_workspace = Button(self.container, text='...', width=1, command=self.callback_path_prompt)
+        self.workspace_container = Frame(self.container)
+        self.label_workspace = Label(self.workspace_container, text='Workspace:')
+        self.entry_workspace = Entry(self.workspace_container, width=60, textvariable=self.sv_workspace)
+        self.button_workspace = Button(self.workspace_container, text='...', width=3, command=self.callback_path_prompt)
+
         # Title block
         self.sv_title = StringVar()
         self.sv_title.trace('w', lambda *args: self.callback_update_path())
         self.label_title = Label(self.container, text='Title:')
         self.entry_title = Entry(self.container, textvariable=self.sv_title)
+
         # Path block
         self.label_path = Label(self.container, text='The project will be created in the following directory:')
         self.entry_path = Entry(self.container, state='readonly')
+
         # Action block
         self.button_create = Button(self.container, text='Create', underline=1, command=self.callback_create)
         self.button_cancel = Button(self.container, text='Cancel', underline=0, command=self.callback_cancel)
@@ -58,22 +62,28 @@ class NewProject(Toplevel):
         :return:
         """
         padding = 3
+
         # Workspace block
         self.label_workspace.grid(row=0, column=0, padx=padding, sticky='SW')
         self.entry_workspace.grid(row=1, column=0, columnspan=4, padx=padding, pady=padding, sticky='NESW')
         self.button_workspace.grid(row=1, column=4, padx=padding, pady=padding, sticky='EW')
+        self.workspace_container.columnconfigure(0, weight=4)
+        self.workspace_container.grid(row=0, column=0, rowspan=2, columnspan=5, sticky='EW')
+
         # Title block
         self.label_title.grid(row=2, column=0, padx=padding, sticky='SW')
         self.entry_title.grid(row=3, column=0, columnspan=5, padx=padding, pady=padding, sticky='EW')
+
         # Path block
         self.label_path.grid(row=4, column=0, padx=padding, sticky='SW')
         self.entry_path.grid(row=5, column=0, columnspan=5, padx=padding, pady=padding, sticky='EW')
+
         # Action block
-        self.button_cancel.grid(row=6, column=2, padx=padding, pady=padding, sticky='EW')
-        self.button_create.grid(row=6, column=3, columnspan=2, padx=padding, pady=padding, sticky='EW')
+        self.button_cancel.grid(row=6, column=3, padx=padding, pady=padding, sticky='EW')
+        self.button_create.grid(row=6, column=4, padx=padding, pady=padding, sticky='EW')
 
         # Specify which portion to auto-expand
-        self.columnconfigure(0, weight=4)
+        self.container.columnconfigure(0, weight=4)
 
         # Place the container frame
         self.container.pack(side=LEFT, fill=BOTH)

--- a/winlogtimeline/ui/tag_settings.py
+++ b/winlogtimeline/ui/tag_settings.py
@@ -10,6 +10,7 @@ class TagSettings(Toplevel):
 
         # Class variables
         self.tags = dict()
+        self.changes_made = False
 
         # Window Parameters
         self.title('Record Tag Settings')
@@ -176,6 +177,7 @@ class TagSettings(Toplevel):
         self.tags[tag] = hex_color
         self.tag_list.config(selectbackground=hex_color)
         self.tag_list.itemconfig(selection[0], bg=hex_color)
+        self.changes_made = True
 
     def callback_add_tag(self, event=None):
         """
@@ -192,6 +194,7 @@ class TagSettings(Toplevel):
         tag = self.tag_list.get(selection[0])
         self.tags.pop(tag)
         self.tag_list.delete(selection[0])
+        self.changes_made = True
 
     def callback_finish(self, event=None):
         """
@@ -201,6 +204,7 @@ class TagSettings(Toplevel):
         self.master.current_project.config['events'] = self.tags
         if self.master.timeline is not None:
             self.master.timeline.update_tags(self.tags)
+        self.master.changes_made |= self.changes_made
         self.destroy()
 
     def callback_cancel(self, event=None):
@@ -266,6 +270,7 @@ class TagPrompt(Toplevel):
             messagebox.showerror('Error', 'That tag already exists.')
             return
         self.master.insert_tag(self.id_entry.get(), '#FFFFFF')
+        self.master.changes_made = True
         self.destroy()
 
     def __destroy__(self):

--- a/winlogtimeline/ui/ui.py
+++ b/winlogtimeline/ui/ui.py
@@ -8,7 +8,7 @@ from winlogtimeline import collector
 from winlogtimeline.util.logs import Record
 from .new_project import NewProject
 from .tag_settings import TagSettings
-from .import_wizard import ImportWizard
+from .import_window import ImportWizard
 import os
 import platform
 


### PR DESCRIPTION
Changes made:

* Implemented a progress bar for use in the log import process. Fixes #40 
* Fixed up the import log UI
* Adjusted the create project UI for consistency
* Restricted the save prompt to only show when changes have been made to the project. 
* Refactored some of the UI for consistency and added documentation on methods I've neglected in previous CRs
* Made a few tweaks to the main UI (project name in the title, import log option in menus). 


Apologies for another large PR. I started digging around in ui.py and noticed a few things I wanted to change. 

@ShaneKent the fix for the issues with import UI was to add a container around the elements that didn't line up with the grid and to make sure that columnconfigure was being called on the container instead of the parent frame. 