### PR TITLE
Fix bugs with duplicate records and duplicate timelines

### DIFF
--- a/winlogtimeline/ui/ui.py
+++ b/winlogtimeline/ui/ui.py
@@ -14,6 +14,8 @@ from .export_timeline import ExportWindow
 from .expanded_view import ExpandedView
 import os
 import platform
+
+
 def enable_disable_wrapper(_lambda):
     def decorate(f):
         def call(*args, **kwargs):
@@ -121,14 +123,19 @@ class GUI(Tk):
         :param alias: A unique alias for the file.
         :return:
         """
+        self.__disable__()
+
         def callback():
             # Prepare status bar callback.
             text = '{file}: {status}'.format(file=os.path.basename(file_name), status='{status}')
 
             # Start the import log process.
-            collector.import_log(file_name, alias, self.current_project, '',
-                                 lambda s: self.update_status_bar(text.format(status=s)),
-                                 self.get_progress_bar_context_manager)
+            try:
+                collector.import_log(file_name, alias, self.current_project, '',
+                                     lambda s: self.update_status_bar(text.format(status=s)),
+                                     self.get_progress_bar_context_manager)
+            except Exception as e:
+                self.update_status_bar(f'Error while importing log: {str(e)}')
 
             # Create or update the timeline.
             self.create_new_timeline()
@@ -183,7 +190,7 @@ class GUI(Tk):
         self.enabled = False
         if self.system != 'Darwin':
             self.toolbar.__disable__()
-            #self.query_bar.__disable__()
+            # self.query_bar.__disable__()
             # self.filter_section.__disable__()
             self.menu_bar.__disable__()
 
@@ -342,6 +349,7 @@ class Timeline(Frame):
             self.master.expanded_view = ExpandedView(self.master)
 
         self.master.expanded_view.update(record[1])
+
 
 class StatusBar(Frame):
     def __init__(self, parent):
@@ -673,7 +681,7 @@ class Filters(Frame):
         self.filterVal.config(width='15')
         self.filterVal.pack(side=LEFT)
 
-        #self.button = Button(self, text="Query", command=lambda: collector.filter.filter_logs(self.master.current_project, self.filter_config()))
+        # self.button = Button(self, text="Query", command=lambda: collector.filter.filter_logs(self.master.current_project, self.filter_config()))
         self.button = Button(self, text="Query", command=lambda: self.apply_filter())
         self.button.pack(side=LEFT)
 
@@ -697,7 +705,8 @@ class Filters(Frame):
 
     def create_opList(self):
         inttype = {'Event ID', 'Record Number', 'Recovered', 'Timestamp (UTC)'}
-        strtype = {'Description', 'Details', 'Event Source', 'Event Log', 'Session ID', 'Account', 'Computer Name', 'Source File Alias'}
+        strtype = {'Description', 'Details', 'Event Source', 'Event Log', 'Session ID', 'Account', 'Computer Name',
+                   'Source File Alias'}
 
         column = self.cvar.get()
         print(column)

--- a/winlogtimeline/util/config/schema.sql
+++ b/winlogtimeline/util/config/schema.sql
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS source_files (
     Connects a specific record to its raw XML data.
  */
 CREATE TABLE IF NOT EXISTS raw_xml_data (
-  record_hash TEXT NOT NULL UNIQUE,
+  record_hash TEXT NOT NULL,
   raw_xml TEXT NOT NULL,
   FOREIGN KEY(record_hash) REFERENCES logs(record_hash)
 );

--- a/winlogtimeline/util/logs.py
+++ b/winlogtimeline/util/logs.py
@@ -33,14 +33,8 @@ class Record:
         )
 
     def __key__(self):
-        key_string = ""
-        key_string += self.timestamp_utc
-        key_string += str(self.event_id)
-        key_string += self.description
-        key_string += self.computer_name
-        key_string += self.event_source
-        key_string += self.event_log
-        return key_string
+        return (f'{self.timestamp_utc}{self.event_id}{self.details}{self.computer_name}{self.event_source}'
+                f'{self.event_log}{self.session_id}{self.account}')
 
     def __hash__(self):
         return hashlib.md5(bytes(self.__key__(), 'utf-8')).hexdigest()

--- a/winlogtimeline/util/project.py
+++ b/winlogtimeline/util/project.py
@@ -94,29 +94,29 @@ class Project:
 
     def write_log_data(self, record, xml):
         """
-        Writes log data to the project as long as it is not a duplicate.
+        Writes log data to the project.
         :param record: A Record object.
+        :param xml: The raw xml for the record.
         :return: None
         """
 
-        if not self.is_duplicate(record):
-            query = ('INSERT INTO logs '
-                     '(timestamp_utc, event_id, description, details, event_source, event_log, session_id, account,'
-                     ' computer_name, record_number, recovered, record_hash, alias) '
-                     'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)')
-            values = (
-                record.timestamp_utc, record.event_id, record.description, record.details, record.event_source,
-                record.event_log, record.session_id, record.account, record.computer_name, record.record_number,
-                record.recovered, record.record_hash, record.source_file_alias
-            )
-            self._conn.execute(query, values)
+        query = ('INSERT INTO logs '
+                 '(timestamp_utc, event_id, description, details, event_source, event_log, session_id, account,'
+                 ' computer_name, record_number, recovered, record_hash, alias) '
+                 'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)')
+        values = (
+            record.timestamp_utc, record.event_id, record.description, record.details, record.event_source,
+            record.event_log, record.session_id, record.account, record.computer_name, record.record_number,
+            record.recovered, record.record_hash, record.source_file_alias
+        )
+        self._conn.execute(query, values)
 
-            query = ('INSERT INTO raw_xml_data '
-                     '(record_hash, raw_xml) '
-                     'VALUES (?, ?)')
+        query = ('INSERT INTO raw_xml_data '
+                 '(record_hash, raw_xml) '
+                 'VALUES (?, ?)')
 
-            values = (record.record_hash, xml)
-            self._conn.execute(query, values)
+        values = (record.record_hash, xml)
+        self._conn.execute(query, values)
 
     def write_verification_data(self, file_hash, log_file, alias):
         """
@@ -155,11 +155,3 @@ class Project:
         aliases = [row[3] for row in rows]
 
         return aliases
-
-    def is_duplicate(self, record):
-        """
-
-        :return:
-        """
-        # TODO: implement and document
-        return False


### PR DESCRIPTION
* Fixed an issue where duplicate records caused errors when being
inserted into the raw_xml_data table.
* Fixed an issue where the user could import two logs at once, resulting
in two timelines being rendered
* Added error reporting to status bar to better diagnose errors
occurring during the log import process.

I had originally tackled the duplicate record issue intending to add better support for duplicates. Unfortunately, any logic I added to detect duplicates during the import process resulted in a massively slowed down import process. As a result, I merely fixed the error and left the rest of the functionality the same. 