### PR TITLE
Fix status bar resizing on windows

### DIFF
--- a/winlogtimeline/ui/ui.py
+++ b/winlogtimeline/ui/ui.py
@@ -176,7 +176,7 @@ class GUI(Tk):
                 r = self.current_project.get_all_logs()
                 if len(r) == 0:
                     self.__enable__()
-                    self.update_status_bar('Done.')
+                    self.update_status_bar('No records to display. ')
                     return
             if h is None:
                 h = Record.get_headers()
@@ -379,7 +379,7 @@ class StatusBar(Frame):
 
     def _place_widgets(self):
         padding = 2
-        self.status.grid(row=0, column=0, padx=padding, pady=padding, sticky='W')
+        self.status.grid(row=0, column=0, padx=padding, pady=padding+2, sticky='W')
         # self.progress.grid(row=0, column=1, padx=padding, pady=padding, sticky='E')
         self.columnconfigure(0, weight=4)
         self.pack(side=BOTTOM, fill=X)


### PR DESCRIPTION
## Summary
<!--- Please include a summary of the changes here --->
I added a small amount of padding on the y-axis of the status bar in order to prevent the progress bar from making it resize. I also changed the message displayed to the user when the program attempts to create a new timeline but no logs are displayed. 

## Related Issues
<!--- Please relate an issue using either "Related to #issuenum" or "Closes #issuenum" --->
Fixes #77 

## Type of Chage
<!--- Please select at least one --->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (this change would somehow cause existing functionality to not beahve as expected)
- [ ] Other

## Testing
<!--- Please describe testing done on this change --->
I opened an empty project, imported a log file, and verified that the issue was no longer present. 

## Checklist:
<!--- Please check off the following items by replacing [ ] with [x] ---> 
- [x] My code follows PEP8 style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
 - *N/A, this is a GUI change and must be verified visually*
- [ ] New and existing unit tests pass locally with my changes
 - *N/A, tests currently fail on my machine due to #101*