### PR TITLE
Convert parser to use event source and event id

### DIFF
--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -1,17 +1,15 @@
 # Run Instructions:
-    # All tests: python3 setup.py test
-    # Just this file: pytest tests/test_collect.py -s
-    # Update code base being tested
-    # pip3 install --upgrade .
-    # pip3 install --user --upgrade .
-
+# All tests: python3 setup.py test
+# Just this file: pytest tests/test_collect.py -s
+# Update code base being tested
+# pip3 install --upgrade .
+# pip3 install --user --upgrade .
 import os
 from winlogtimeline.collector import collect
 from winlogtimeline.util import project
 from winlogtimeline.ui import ui
 from hashlib import md5
 import shutil
-import xmltodict
 import pyevtx
 import mock
 
@@ -29,15 +27,14 @@ text = '{file}: {status}'.format(file=os.path.basename(record_file), status='{st
 @mock.patch('winlogtimeline.collector.collect.xml_convert')
 @mock.patch.object(proj, 'write_log_data')
 @mock.patch.object(proj, 'write_verification_data')
-
 def test_import_log_func_calls(mock_verify_data, mock_log_data, mock_xml, mock_collect):
     collect.import_log(record_file, 'Secure', proj, '', lambda s: gui.update_status_bar(text.format(status=s)),
                        gui.get_progress_bar_context_manager)
 
-    assert(mock_collect.called) == True
-    assert(mock_xml.called) == True
-    #assert(mock_log_data.called) == True # why is this false not true? Issues with loop possibly?
-    assert(mock_verify_data.called) == True
+    assert mock_collect.called
+    assert mock_xml.called
+    # assert mock_log_data.called  # why is this false not true? Issues with loop possibly?
+    assert mock_verify_data.called
 
 
 @mock.patch('winlogtimeline.collector.parser.parser')
@@ -49,7 +46,8 @@ def test_xml_convert(mock_parser):
     log = pyevtx.open(record_file)
     records = collect.collect_records(log)  # + collect_deleted_records(log)
     xml_records = collect.xml_convert(records, file_hash, 'test')
-    #assert(mock_parser.called) == True # Another issue with loops?
+    # assert mock_parser.called  # Another issue with loops?
+
 
 # Remove testing project
 proj.close()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,9 +1,9 @@
 # Run Instructions:
-    # All tests: python3 setup.py test
-    # Just this file: pytest tests/test_parser.py -s
-    # Update code base being tested
-    # pip3 install --upgrade .
-    # pip3 install --user --upgrade .
+# All tests: python3 setup.py test
+# Just this file: pytest tests/test_parser.py -s
+# Update code base being tested
+# pip3 install --upgrade .
+# pip3 install --user --upgrade .
 
 import os
 from xml.parsers.expat import ExpatError
@@ -1049,7 +1049,7 @@ def test_parse_unwanted():
 def test_parse_wanted():
     xmlWanted = '<Event xmlns = "http://schemas.microsoft.com/win/2004/08/events/event">' + \
                '<System>' + \
-               '<Provider Name="Microsoft-Windows-Kernel-General" Guid="{A68CA8B7-004F-D7B6-A698-07E2DE0F1F5D}"/>' + \
+               '<Provider Name="Microsoft-Windows-Power-Troubleshooter" Guid="{A68CA8B7-004F-D7B6-A698-07E2DE0F1F5D}"/>' + \
                '<EventID>1</EventID>' + \
                '<Version>1</Version>' + \
                '<Level>4</Level>' + \

--- a/winlogtimeline/collector/collect.py
+++ b/winlogtimeline/collector/collect.py
@@ -119,7 +119,6 @@ def xml_convert(records, source_file_alias, recovered=False):
 
         yield (dictionary, record)
 
-
 def collect_records(event_file):
     """
     :param event_file: An event log object.


### PR DESCRIPTION
## Summary
<!--- Please include a summary of the changes here --->
- Changed the parser to identify events using both event source and event id instead of just event id
- Added some code to help with user-configured records
- Cleaned up some of the parser
- Modified one test to reflect the event sources now being dropped

## Related Issues
<!--- Please relate an issue using either "Related to #issuenum" or "Closes #issuenum" --->
- Closes #60 
- Related to #102 

## Type of Chage
<!--- Please select at least one --->
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (this change would somehow cause existing functionality to not beahve as expected)
- [ ] Other

## Testing
<!--- Please describe testing done on this change --->
Ran the parser tests to ensure that all records were still being parsed properly. 

## Checklist:
<!--- Please check off the following items by replacing [ ] with [x] ---> 
- [x] My code follows PEP8 style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
