### PR TITLE
Change tag settings listbox to treeview

### DIFF
--- a/winlogtimeline/util/config/config.json
+++ b/winlogtimeline/util/config/config.json
@@ -1,7 +1,6 @@
 {
   "events": {
     "Microsoft-Windows-Kernel-General::12": "#82C93F",
-    "Microsoft-Windows-UserModePowerService::12": "#82C93F",
     "Microsoft-Windows-Kernel-General::13": "#F73B31",
     "Microsoft-Windows-Security-Auditing::4616": "#B1B2B1",
     "Microsoft-Windows-Kernel-Power::41": "#FD8727",


### PR DESCRIPTION
## Summary
<!--- Please include a summary of the changes here --->
Cleaned up the tag settings to use a multi-column widget, which should be more user-friendly. Unfortunately, I was unable to change the selection background in the new treeview widget. Instead, I added a box which shows the current color (and as an added bonus has black text, so the user can tell how readable the label will be). 

## Related Issues
<!--- Please relate an issue using either "Related to #issuenum" or "Closes #issuenum" --->
N/A

## Type of Chage
<!--- Please select at least one --->
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (this change would somehow cause existing functionality to not beahve as expected)
- [ ] Other

## Testing
<!--- Please describe testing done on this change --->
Ran through all functionality associated with the tag settings window. 

## Checklist:
<!--- Please check off the following items by replacing [ ] with [x] ---> 
- [x] My code follows PEP8 style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
