### PR TITLE
Persistent filters and dedup

### DIFF
--- a/winlogtimeline/collector/filter.py
+++ b/winlogtimeline/collector/filter.py
@@ -36,6 +36,9 @@ def filter_logs(project, config, dedup):
             value = "'" + value + "'"
             if len(value.split()) == 1:
                 col = 'date(' + col + ')'
+        elif datatype == 'INTEGER':
+            try: int(value) #Non-integer values for int type columns are invalid
+            except: continue
         filters.append((col, operator, value))
         #config = [(col, operator, value)]
 

--- a/winlogtimeline/collector/filter.py
+++ b/winlogtimeline/collector/filter.py
@@ -28,7 +28,6 @@ def filter_logs(project, config, dedup):
         elif operator == 'In':
             value = "(" + value + ")" #Add parentheses for sql list
 
-        #columns = [col_info[1] for col_info in info]
         idx = headers.index(col)
         col = columns[idx]
         datatype = types[idx] #Data type for this column
@@ -40,7 +39,6 @@ def filter_logs(project, config, dedup):
             try: int(value) #Non-integer values for int type columns are invalid
             except: continue
         filters.append((col, operator, value))
-        #config = [(col, operator, value)]
 
     # Timestamp offset
     offset = project.config['state']['timezone_offset']

--- a/winlogtimeline/collector/filter.py
+++ b/winlogtimeline/collector/filter.py
@@ -1,11 +1,12 @@
 from winlogtimeline.util.logs import Record
 
-def filter_logs(project, config):
+def filter_logs(project, config, dedup):
     """
     When given a list of log objects, returns only those that match the filters defined in config and project. The
     filters in project take priority over config.
     :param project: A project instance.
     :param config: A config dictionary.
+    :param dedup: Int var specifying deduplication
     :return: A list of logs that satisfy the filters specified in the configuration.
     """
 
@@ -48,7 +49,8 @@ def filter_logs(project, config):
              f'alias, record_hash FROM logs WHERE ')
     for constraint in filters:
         query += '{} {} {} AND '.format(*constraint)
-    query = query[:-5] + ' GROUP BY record_hash'
+    query = query[:-5]
+    if dedup.get() != 0: query += ' GROUP BY record_hash'
     print(query)
 
     cur = project._conn.execute(query)

--- a/winlogtimeline/ui/filter_window.py
+++ b/winlogtimeline/ui/filter_window.py
@@ -98,7 +98,7 @@ class FilterWindow(Toplevel):
 
         for f in self.checkbuttons:
             print('xzx')
-            f.grid(row=i, column=0, columnspan=1, sticky='NWES')
+            f.grid(row=i, column=0, columnspan=1, sticky='NWES', padx=padding)
             i += 1
 
         # Workspace block
@@ -159,5 +159,5 @@ class FilterWindow(Toplevel):
         for i in range(len(self.check_vars)):
             self.master.master.current_project.config['filters'][i][-1] = self.check_vars[i].get()
 
-        self.master.apply_filter()
+        self.master.master.create_new_timeline()
         self.destroy()

--- a/winlogtimeline/ui/filter_window.py
+++ b/winlogtimeline/ui/filter_window.py
@@ -2,6 +2,7 @@ from tkinter import *
 from tkinter import filedialog, messagebox
 from tkinter.ttk import *
 
+
 class FilterWindow(Toplevel):
     def __init__(self, parent, current_project):
         super().__init__(parent)
@@ -16,7 +17,6 @@ class FilterWindow(Toplevel):
         # Create and place the widgets
         self._init_widgets()
         self._place_widgets()
-
 
     def _init_widgets(self):
         """
@@ -39,7 +39,6 @@ class FilterWindow(Toplevel):
         # Filter columns drop down menu
         self.columns = OptionMenu(self.container, self.cvar, *self.colList)
         self.columns.config(width='17')
-
 
         self.opList = ['- Select Operation -']
 
@@ -65,19 +64,18 @@ class FilterWindow(Toplevel):
         self.checkbuttons = []
 
         try:
-            #Check if filters exists yet
+            # Check if filters exists yet
             filters = self.master.master.current_project.config['filters']
         except KeyError:
             self.master.master.current_project.config['filters'] = []
             filters = self.master.master.current_project.config['filters']
-
 
         for i, filter in enumerate(filters):
             label = filter[0] + ' ' + filter[1] + ' ' + filter[2]
             print(label)
             val = filter[3]
             self.check_vars.append(IntVar(value=val))
-            self.checkbuttons.append(Checkbutton(self.work_container, text=label,variable=self.check_vars[i]))
+            self.checkbuttons.append(Checkbutton(self.work_container, text=label, variable=self.check_vars[i]))
 
         self.cvar.trace_add('write', lambda *args: self.create_opList())
 
@@ -92,27 +90,23 @@ class FilterWindow(Toplevel):
         padding = 3
         i = 1
 
-        self.columns.grid(row=0, column = 0, columnspan=1, sticky='NW')
-        self.operations.grid(row=0, column = 1, columnspan=1, sticky='NW')
-        self.filterVal.grid(row=0, column = 2, columnspan=1, sticky='NW')
-        self.addButton.grid(row=0, column = 3, columnspan=1, sticky='NW')
-        self.qButton.grid(row=0, column = 4, columnspan=1, sticky='NW')
+        self.columns.grid(row=0, column=0, columnspan=1, sticky='NW')
+        self.operations.grid(row=0, column=1, columnspan=1, sticky='NW')
+        self.filterVal.grid(row=0, column=2, columnspan=1, sticky='NW')
+        self.addButton.grid(row=0, column=3, columnspan=1, sticky='NW')
+        self.qButton.grid(row=0, column=4, columnspan=1, sticky='NW')
 
         for f in self.checkbuttons:
             print('xzx')
-            i+=1
-
-
             f.grid(row=i, column=0, columnspan=1, sticky='NWES')
-
+            i += 1
 
         # Workspace block
         self.work_container.columnconfigure(0, weight=4)
-        self.work_container.grid(row=0, column=0, columnspan=5, rowspan=12, sticky='NW')
+        self.work_container.grid(row=1, column=0, columnspan=5, rowspan=12, sticky='NW')
 
-        #self.container.columnconfigure(0, weight=4)
+        # self.container.columnconfigure(0, weight=4)
         self.container.grid(row=0, column=0)
-
 
     def create_opList(self):
         inttype = {'Event ID', 'Record Number', 'Recovered', 'Timestamp (UTC)', 'Timestamp'}
@@ -139,14 +133,14 @@ class FilterWindow(Toplevel):
         filter = [self.cvar.get(), self.ovar.get(), self.filterVal.get(), 1]
         label = ' '.join(filter[:3])
 
-        #Disallow empty values
+        # Disallow empty values
         if filter[0] == '- Select Column -' or filter[1] == '- Select Operation -':
             return
         if filter[2] == '' or filter[2] == None:
             print('No value entered!')
             return
 
-        #Disallow duplicate filters
+        # Disallow duplicate filters
         for f in self.master.master.current_project.config['filters']:
             if f[0] == filter[0] and f[1] == filter[1] and f[2] == filter[2]:
                 print('Duplicate filter detected')

--- a/winlogtimeline/ui/filter_window.py
+++ b/winlogtimeline/ui/filter_window.py
@@ -64,7 +64,15 @@ class FilterWindow(Toplevel):
         self.check_vars = []
         self.checkbuttons = []
 
-        for i, filter in enumerate(self.master.filters):
+        try:
+            #Check if filters exists yet
+            filters = self.master.master.current_project.config['filters']
+        except KeyError:
+            self.master.master.current_project.config['filters'] = []
+            filters = self.master.master.current_project.config['filters']
+
+
+        for i, filter in enumerate(filters):
             label = filter[0] + ' ' + filter[1] + ' ' + filter[2]
             print(label)
             val = filter[3]
@@ -128,23 +136,23 @@ class FilterWindow(Toplevel):
     def add_filter(self):
         padding = 3
 
-        config = [self.cvar.get(), self.ovar.get(), self.filterVal.get(), 1]
-        label = ' '.join(config[:3])
+        filter = [self.cvar.get(), self.ovar.get(), self.filterVal.get(), 1]
+        label = ' '.join(filter[:3])
 
         #Disallow empty values
-        if config[0] == '- Select Column -' or config[1] == '- Select Operation -':
+        if filter[0] == '- Select Column -' or filter[1] == '- Select Operation -':
             return
-        if config[2] == '' or config[2] == None:
+        if filter[2] == '' or filter[2] == None:
             print('No value entered!')
             return
 
         #Disallow duplicate filters
-        for f in self.master.filters:
-            if f[0] == config[0] and f[1] == config[1] and f[2] == config[2]:
+        for f in self.master.master.current_project.config['filters']:
+            if f[0] == filter[0] and f[1] == filter[1] and f[2] == filter[2]:
                 print('Duplicate filter detected')
                 return
 
-        self.master.filters.append(config)
+        self.master.master.current_project.config['filters'].append(filter)
 
         idx = len(self.check_vars) + 1
         self.check_vars.append(IntVar(value=1))
@@ -155,7 +163,7 @@ class FilterWindow(Toplevel):
     def apply_filters(self):
 
         for i in range(len(self.check_vars)):
-            self.master.filters[i][-1] = self.check_vars[i].get()
+            self.master.master.current_project.config['filters'][i][-1] = self.check_vars[i].get()
 
         self.master.apply_filter()
         self.destroy()

--- a/winlogtimeline/ui/ui.py
+++ b/winlogtimeline/ui/ui.py
@@ -787,17 +787,21 @@ class Filters(Frame):
         super().__init__(parent, **kwargs)
         self.pack(side=TOP, fill=X)
 
-        # Filter Label
-        # self.flabel = Label(self, text='Filters:', anchor=W, **kwargs)
-        # self.flabel.pack(side=LEFT)
-
         self.filters = []
 
         self.advanced = Button(self, text="Filters", command=lambda: self.advanced_filter_function())
         self.advanced.pack(side=LEFT)
 
-        self.clear = Button(self, text="Clear", command=lambda: self.master.create_new_timeline())
+        self.clear = Button(self, text="Clear", command=lambda: self.clear_timeline())
         self.clear.pack(side=LEFT)
+
+        self.dedup_var = IntVar(value=0)
+        self.dedup = Checkbutton(self, text="Deduplicate", variable=self.dedup_var)
+        self.dedup.pack(side=LEFT)
+
+        #self.dedup_var.trace('w', self.apply_filter())
+
+
 
     def __disable__(self):
         self.flabel.config(state=DISABLED)
@@ -807,21 +811,23 @@ class Filters(Frame):
         self.flabel.config(state=NORMAL)
         self.columns.config(state=NORMAL)
 
-    '''def get_opList(self):
-        return self.opList'''
-
     def create_colList(self, colList):
         tmp = Record.get_headers()
         for col in tmp:
             colList.append(col)
 
+    @enable_disable_wrapper(lambda *args: args[0].master)
     def apply_filter(self):
-        # config = self.filter_config()
-        logs = collector.filter_logs(self.master.current_project, self.filters)
+        logs = collector.filter_logs(self.master.current_project, self.filters, self.dedup_var)
 
         self.master.create_new_timeline(records=logs)
         print('Found {} records'.format(len(logs)))
         # self.master.status_bar.update_status('text')
+
+
+    @enable_disable_wrapper(lambda *args: args[0].master)
+    def clear_timeline(self):
+        self.master.create_new_timeline()
 
     @enable_disable_wrapper(lambda *args: args[0].master)
     def advanced_filter_function(self, event=None):

--- a/winlogtimeline/ui/ui.py
+++ b/winlogtimeline/ui/ui.py
@@ -166,8 +166,8 @@ class GUI(Tk):
         Returns a list of records with the filter applied. Meant for use in the export process.
         :return:
         """
-        config = self.filter_section.filters
-        return collector.filter_logs(self.current_project, config)
+        config = self.current_project.config['filters']
+        return collector.filter_logs(self.current_project, config, IntVar(0)) #This should be dedup_var from Filters
 
     def create_new_timeline(self, headers=None, records=None):
         """

--- a/winlogtimeline/ui/ui.py
+++ b/winlogtimeline/ui/ui.py
@@ -185,8 +185,8 @@ class GUI(Tk):
             self.update_status_bar('Loading records...')
             # Get all records if they weren't provided
             if records is None:
-                # TODO: Modify this to apply any queries that may exist
-                records = self.current_project.get_all_logs()
+                records = self.filter_section.apply_filter()
+                # records = self.current_project.get_all_logs()
                 if len(records) == 0:
                     self.__enable__()
                     self.update_status_bar('No records to display. ')
@@ -814,14 +814,12 @@ class Filters(Frame):
         for col in tmp:
             colList.append(col)
 
-    @enable_disable_wrapper(lambda *args: args[0].master)
     def apply_filter(self):
-        logs = collector.filter_logs(self.master.current_project, self.master.current_project.config['filters'], self.dedup_var)
-
-        self.master.create_new_timeline(records=logs)
-        print('Found {} records'.format(len(logs)))
-        # self.master.status_bar.update_status('text')
-
+        if 'filters' in self.master.current_project.config:
+            return collector.filter_logs(self.master.current_project, self.master.current_project.config['filters'],
+                                         self.dedup_var)
+        else:
+            return self.master.current_project.get_all_logs()
 
     @enable_disable_wrapper(lambda *args: args[0].master)
     def clear_timeline(self):

--- a/winlogtimeline/ui/ui.py
+++ b/winlogtimeline/ui/ui.py
@@ -787,8 +787,6 @@ class Filters(Frame):
         super().__init__(parent, **kwargs)
         self.pack(side=TOP, fill=X)
 
-        self.filters = []
-
         self.advanced = Button(self, text="Filters", command=lambda: self.advanced_filter_function())
         self.advanced.pack(side=LEFT)
 
@@ -818,7 +816,7 @@ class Filters(Frame):
 
     @enable_disable_wrapper(lambda *args: args[0].master)
     def apply_filter(self):
-        logs = collector.filter_logs(self.master.current_project, self.filters, self.dedup_var)
+        logs = collector.filter_logs(self.master.current_project, self.master.current_project.config['filters'], self.dedup_var)
 
         self.master.create_new_timeline(records=logs)
         print('Found {} records'.format(len(logs)))


### PR DESCRIPTION
## Summary
Added a checkbutton for deduplication. Query button in filter menu must be pressed for timeline to reload with new results. Filters are now stored in projects config dictionary. Filters are persistent. Exporting with filters is supported. Also fixed some bugs with allowed filter values. 

## Related Issues
Closes #126
Closes #129

## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Breaking change (this change would somehow cause existing functionality to not behave as expected)
- [ ] Other

## Testing
Exported with filters. 
Verified deduplication. 

## Checklist:
<!--- Please check off the following items by replacing [ ] with [x] ---> 
- [X] My code follows PEP8 style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
